### PR TITLE
SCAL-169409 : Error handling

### DIFF
--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -11,6 +11,8 @@ export default async function handler(request) {
     file_format: 'PNG',
   });
   let res;
+  //For logging in Axiom
+  console.log('Proxy request body',requestBody);
   try {
     res = await fetchEndpoint(
       requestBody.endpoint,
@@ -18,7 +20,7 @@ export default async function handler(request) {
       requestBody.token,
       requestBody.payload
     );
-    console.log('Proxy res received');
+    console.log('Proxy res received', res);
   } catch (e) {
     console.log('Proxy res Failed', e);
     res = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "@thoughtspot/visual-embed-sdk": "1.24.0",
+        "@thoughtspot/visual-embed-sdk": "1.24.4",
+        "@vercel/analytics": "^1.0.2",
         "preact": "^10.11.13",
         "vercel": "30.2.2"
       },
@@ -3834,9 +3835,9 @@
       }
     },
     "node_modules/@thoughtspot/visual-embed-sdk": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@thoughtspot/visual-embed-sdk/-/visual-embed-sdk-1.24.0.tgz",
-      "integrity": "sha512-rXdU2b47Uu22kTASjzPEA8bVP3ekDI815wr5arQfKWcaaIIgYoe0x0PY+3b6t2rDMVETGQSiVt7A0RxmR/hdWQ==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@thoughtspot/visual-embed-sdk/-/visual-embed-sdk-1.24.4.tgz",
+      "integrity": "sha512-nmr0TtWSK/qIfW+OyqMSnszubFIEW627uRwEc7kroBP+gfUyZA/X74mGQeKcd3gTjHYzGY5REtv1ek1Vcp1rvw==",
       "dependencies": {
         "algoliasearch": "^4.10.5",
         "classnames": "^2.3.1",
@@ -4589,6 +4590,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.3.tgz",
       "integrity": "sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ=="
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.1.0.tgz",
+      "integrity": "sha512-k5ePYZPxitxxD1eJenPUUuH3qK+EtaA9OVD3oO0BRbyT/LarmZF0qdkptRSidip1arQxsTEIWvHbTuj1oksl+Q==",
+      "dependencies": {
+        "server-only": "^0.0.1"
+      }
     },
     "node_modules/@vercel/build-utils": {
       "version": "6.7.5",
@@ -16238,6 +16247,11 @@
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
       "dev": true
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "vitest": "^0.30.1"
   },
   "dependencies": {
-    "@thoughtspot/visual-embed-sdk": "1.24.0",
+    "@thoughtspot/visual-embed-sdk": "1.24.4",
     "preact": "^10.11.13",
-    "vercel": "30.2.2"
+    "vercel": "30.2.2",
+    "@vercel/analytics": "^1.0.2"
   },
   "workspaces": [
     "packages/*"

--- a/packages/i18n/strings/en.json
+++ b/packages/i18n/strings/en.json
@@ -34,7 +34,9 @@
   "YOURS": "Yours",
   "ANSWERS": "Answers",
   "LIVEBOARDS": "Liveboards",
-  "INSERT_FAILURE_MESSAGE":"Insert failed, please try again",
+  "INSERT_FAILURE_MESSAGE":"Insert failed, please try again.\n\n If issue persists please contact ThoughtSpot support",
   "BROSWER_NOT_SUPPORTED": "Browser not supported",
-  "BROSER_RECCOMENDATION":"This plugin is only supported on Google Chrome."
+  "BROSER_RECCOMENDATION":"This plugin is only supported on Google Chrome.",
+  "TOKEN_FETCH_FAILED": "Failed to fetch token!\n\nPlease relaunch the extension to retry.",
+  "PRIVILEGE_REQUIRED": "You need the privilege `Can download Data` to access this extension. Please contact your administrator"
 }

--- a/packages/sheets/src/ui/components/app.tsx
+++ b/packages/sheets/src/ui/components/app.tsx
@@ -6,6 +6,7 @@ import {
   defaultShellContextOptions,
 } from 'gsuite-shell';
 import { I18N } from 'i18n';
+import { Analytics } from '@vercel/analytics/react';
 import { TSInit } from 'ts-init';
 import { TSSearchBar } from './search-bar/search-bar';
 
@@ -16,6 +17,7 @@ export function App() {
     <I18N>
       <ShellContext.Provider value={defaultShellContextOptions}>
         <TSInit>
+          <Analytics />
           <TSSearchBar />
         </TSInit>
       </ShellContext.Provider>

--- a/packages/slides/src/ui/components/answer/answer.module.scss
+++ b/packages/slides/src/ui/components/answer/answer.module.scss
@@ -1,13 +1,4 @@
 .answerIframe {
-    height: 100%;
-    width: 100%;
-  }
-
-.errorBanner {
-  justify-content: space-between;
-  padding: 10px;
-}
-
-.errorButton{
-background: transparent;
+  height: 100%;
+  width: 100%;
 }

--- a/packages/slides/src/ui/components/answer/answer.tsx
+++ b/packages/slides/src/ui/components/answer/answer.tsx
@@ -4,14 +4,11 @@ import { useRouter } from 'preact-router';
 import { useEffect, useState } from 'preact/hooks';
 import { useShellContext } from 'gsuite-shell';
 import { useLoader } from 'widgets/lib/loader';
-import { Typography, Colors } from 'widgets/lib/typography';
-import { Horizontal, Vertical } from 'widgets/lib/layout/flex-layout';
-import { Button } from 'widgets/lib/button';
-import { Icon } from 'widgets/lib/icon';
+import { Vertical } from 'widgets/lib/layout/flex-layout';
 import { useTranslations } from 'i18n';
+import { ErrorBanner } from 'widgets/lib/error-banner';
 import styles from './answer.module.scss';
 import { getTSAnswerLink } from '../../utils';
-import { exportAnswer } from '../../services/api';
 import { customCSSProperties } from './answer.util';
 
 export const Answer = () => {
@@ -45,24 +42,11 @@ export const Answer = () => {
   }, [ref.current]);
   return (
     <Vertical className={styles.answerIframe}>
-      {showError && (
-        <Horizontal
-          vAlignContent="center"
-          spacing="e"
-          className={styles.errorBanner}
-        >
-          <Typography variant="h6" noMargin color={Colors.failure}>
-            {t.INSERT_FAILURE_MESSAGE}
-          </Typography>
-          <Button
-            type="ICON"
-            className={styles.errorButton}
-            onClick={() => setShowError(false)}
-          >
-            <Icon name="rd-icon-cross" size="xs"></Icon>
-          </Button>
-        </Horizontal>
-      )}
+      <ErrorBanner
+        errorMessage={t.INSERT_FAILURE_MESSAGE}
+        showBanner={showError}
+        onCloseIconClick={() => setShowError(false)}
+      />
       <SearchEmbed
         ref={ref}
         answerId={answerId}

--- a/packages/slides/src/ui/components/app.tsx
+++ b/packages/slides/src/ui/components/app.tsx
@@ -1,6 +1,7 @@
 import Router from 'preact-router';
 import { createMemoryHistory, createHashHistory } from 'history';
 import { ShellContext, defaultShellContextOptions } from 'gsuite-shell';
+import { Analytics } from '@vercel/analytics/react';
 import { I18N } from 'i18n';
 import { TSInit } from 'ts-init';
 import React from 'preact';
@@ -23,6 +24,7 @@ export function App() {
         <TSInit>
           <Header history={history}></Header>
           <div className={styles.content}>
+            <Analytics />
             <AppContextProvider>
               <PrerenderdLiveboardProvider>
                 <Router history={history}>

--- a/packages/slides/src/ui/components/home/home.tsx
+++ b/packages/slides/src/ui/components/home/home.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { route } from 'preact-router';
 import { useLoader } from 'widgets/lib/loader';
 import { Vertical } from 'widgets/lib/layout/flex-layout';
@@ -6,60 +6,93 @@ import { useTranslations } from 'i18n';
 import { Card } from 'widgets/lib/card';
 import { useShellContext } from 'gsuite-shell';
 import { getSessionInfo } from '@thoughtspot/visual-embed-sdk';
-import { getPath, Routes } from '../../routes';
+import { ErrorBanner, BannerType } from 'widgets/lib/error-banner';
+import { Routes } from '../../routes';
 import styles from './home.module.scss';
 import { getToken } from '../../services/api';
-import { useAppContext } from '../app.context';
 
 export const Home = () => {
   const loader = useLoader();
   const { run } = useShellContext();
   const { t } = useTranslations();
-  const { setUserID, userID } = useAppContext();
+  const [errorMessage, setErrorMessage] = useState({
+    visible: true,
+    message: '',
+  });
+  const [isPrivileged, setIsPrivileged] = useState(false);
 
   useEffect(() => {
     const getUserInfo = async () => {
       const userInfo = await getSessionInfo();
-      setUserID(userInfo?.userGUID);
+      const isUserPrivileged =
+        userInfo?.privileges?.includes('DATADOWNLOADING') ||
+        userInfo?.privileges?.includes('ADMINISTRATION');
+      setIsPrivileged(isUserPrivileged);
+      if (!isUserPrivileged) {
+        setErrorMessage({ visible: true, message: t.PRIVILEGE_REQUIRED });
+        loader.hide();
+      }
     };
     getUserInfo();
   }, []);
 
   useEffect(() => {
-    getToken().then((token) => {
-      run('setToken', token.token, token.ttl);
-    });
-    loader.hide();
-  }, []);
+    if (isPrivileged) {
+      getToken().then((token) => {
+        if (token.token) {
+          run('setToken', token.token, token.ttl);
+          setErrorMessage({
+            visible: false,
+            message: '',
+          });
+        } else {
+          setErrorMessage({ visible: true, message: t.TOKEN_FETCH_FAILED });
+        }
+        loader.hide();
+      });
+    }
+  }, [isPrivileged]);
 
   return (
     <Vertical className={styles.home} spacing="c">
-      <Card
-        id={0}
-        title={t.INSERT_TS_VIZ}
-        subTitle={t.INSERT_TS_VIZ_DESCRIPTION}
-        firstButton={t.BROWSE_TS}
-        firstButtonType={'PRIMARY'}
-        onFirstButtonClick={() => route(Routes.LIVEBOARDLIST)}
-        isFirstButtonDisabled={userID === ''}
-      />
-      <Card
-        id={1}
-        title={t.UPDATE_VIZ}
-        subTitle={t.UPDATE_VIZ_DESCRIPTION}
-        firstButton={t.UPDATE_ALL_VIZ}
-        firstButtonType="SECONDARY"
-        onFirstButtonClick={() => {
-          loader.show();
-          run('reloadImagesInPresentation').then(() => loader.hide());
+      <ErrorBanner
+        errorMessage={errorMessage.message}
+        bannerType={BannerType.CARD}
+        errorCardButton={{
+          name: '',
         }}
-        secondButton={t.UPDATE_VIZ_IN_SLIDE}
-        secondButtonType={'SECONDARY'}
-        onSecondButtonClick={() => {
-          loader.show();
-          run('reloadImagesInCurrentSlide').then(() => loader.hide());
-        }}
+        showCloseIcon={false}
+        showBanner={errorMessage.visible && !!errorMessage.message}
       />
+      {!errorMessage.visible && !errorMessage.message && (
+        <>
+          <Card
+            id={0}
+            title={t.INSERT_TS_VIZ}
+            subTitle={t.INSERT_TS_VIZ_DESCRIPTION}
+            firstButton={t.BROWSE_TS}
+            firstButtonType={'PRIMARY'}
+            onFirstButtonClick={() => route(Routes.LIVEBOARDLIST)}
+          />
+          <Card
+            id={1}
+            title={t.UPDATE_VIZ}
+            subTitle={t.UPDATE_VIZ_DESCRIPTION}
+            firstButton={t.UPDATE_ALL_VIZ}
+            firstButtonType="SECONDARY"
+            onFirstButtonClick={() => {
+              loader.show();
+              run('reloadImagesInPresentation').then(() => loader.hide());
+            }}
+            secondButton={t.UPDATE_VIZ_IN_SLIDE}
+            secondButtonType={'SECONDARY'}
+            onSecondButtonClick={() => {
+              loader.show();
+              run('reloadImagesInCurrentSlide').then(() => loader.hide());
+            }}
+          />
+        </>
+      )}
     </Vertical>
   );
 };

--- a/packages/slides/src/ui/components/liveboard/liveboard.module.scss
+++ b/packages/slides/src/ui/components/liveboard/liveboard.module.scss
@@ -4,12 +4,3 @@
   overflow: hidden;
   position: relative;
 }
-
-.errorBanner {
-  justify-content: space-between;
-  padding: 10px;
-}
-
-.errorButton{
-background: transparent;
-}

--- a/packages/slides/src/ui/components/liveboard/liveboard.tsx
+++ b/packages/slides/src/ui/components/liveboard/liveboard.tsx
@@ -8,11 +8,9 @@ import { createContext } from 'preact';
 import { useRouter } from 'preact-router';
 import { useEffect, useContext, useRef, useState } from 'preact/hooks';
 import { useLoader } from 'widgets/lib/loader';
-import { Horizontal, Vertical } from 'widgets/lib/layout/flex-layout';
-import { Colors, Typography } from 'widgets/lib/typography';
-import { Button } from 'widgets/lib/button';
-import { Icon } from 'widgets/lib/icon';
+import { Vertical } from 'widgets/lib/layout/flex-layout';
 import { useTranslations } from 'i18n';
+import { ErrorBanner } from 'widgets/lib/error-banner';
 import styles from './liveboard.module.scss';
 import { getOffset, getTSLBVizLink } from '../../utils';
 
@@ -95,24 +93,11 @@ export const Liveboard = () => {
   }, []);
   return (
     <Vertical className={styles.liveboardContainer}>
-      {showError && (
-        <Horizontal
-          vAlignContent="center"
-          spacing="e"
-          className={styles.errorBanner}
-        >
-          <Typography variant="h6" noMargin color={Colors.failure}>
-            {t.INSERT_FAILURE_MESSAGE}
-          </Typography>
-          <Button
-            type="ICON"
-            className={styles.errorButton}
-            onClick={() => setShowError(false)}
-          >
-            <Icon name="rd-icon-cross" size="xs"></Icon>
-          </Button>
-        </Horizontal>
-      )}
+      <ErrorBanner
+        errorMessage={t.INSERT_FAILURE_MESSAGE}
+        showBanner={showError}
+        onCloseIconClick={() => setShowError(false)}
+      />
       <div className={styles.liveboardContainer} ref={ref}></div>
     </Vertical>
   );

--- a/packages/ts-init/src/ts-auth-init/ts-auth-init.tsx
+++ b/packages/ts-init/src/ts-auth-init/ts-auth-init.tsx
@@ -23,6 +23,7 @@ const initTSBasic = (url: string, username: string, password: string) => {
     authType: AuthType.Basic,
     username,
     password,
+    detectCookieAccessSlow: true,
   });
 };
 

--- a/packages/widgets/src/button/index.tsx
+++ b/packages/widgets/src/button/index.tsx
@@ -4,7 +4,7 @@ import styles from './button.module.scss';
 export interface ButtonProps {
   type?: 'PRIMARY' | 'SECONDARY' | 'ICON';
   className?: string;
-  children?: any[];
+  children?: any;
   text?: string;
   onClick: (e) => void;
   id?: string;

--- a/packages/widgets/src/error-banner/banner.module.scss
+++ b/packages/widgets/src/error-banner/banner.module.scss
@@ -1,0 +1,8 @@
+.errorBanner {
+    justify-content: space-between;
+    padding: 10px;
+}
+
+.errorButton {
+    background: transparent;
+}

--- a/packages/widgets/src/error-banner/error.banner.tsx
+++ b/packages/widgets/src/error-banner/error.banner.tsx
@@ -1,0 +1,71 @@
+import cx from 'classnames';
+import { Card } from '../card';
+import { Button } from '../button';
+import { Icon } from '../icon';
+import { Horizontal } from '../layout/flex-layout';
+import { Typography, Colors, Variants } from '../typography';
+import styles from './banner.module.scss';
+
+export enum BannerType {
+  CARD,
+  MESSAGE,
+}
+
+export interface ErrorBannerProps {
+  errorMessage: string;
+  showBanner?: boolean;
+  bannerType?: BannerType;
+  errorCardButton?: {
+    name?: string;
+    onClick?: () => void;
+  };
+  messageSize?: Variants;
+  className?: string;
+  showCloseIcon?: boolean;
+  onCloseIconClick?: (message: string) => void;
+}
+export const ErrorBanner: React.FC<ErrorBannerProps> = ({
+  errorMessage,
+  bannerType = BannerType.MESSAGE,
+  errorCardButton,
+  showBanner = true,
+  className,
+  messageSize = 'h6',
+  showCloseIcon = true,
+  onCloseIconClick,
+}) => {
+  return (
+    <>
+      {showBanner && bannerType === BannerType.MESSAGE && (
+        <Horizontal
+          vAlignContent="center"
+          spacing="e"
+          className={cx(styles.errorBanner, className)}
+        >
+          <Typography variant={messageSize} noMargin color={Colors.failure}>
+            {errorMessage}
+          </Typography>
+          {showCloseIcon && (
+            <Button
+              type="ICON"
+              className={styles.errorButton}
+              onClick={onCloseIconClick}
+            >
+              <Icon name="rd-icon-cross" size="xs"></Icon>
+            </Button>
+          )}
+        </Horizontal>
+      )}
+      {showBanner && bannerType === BannerType.CARD && (
+        <Card
+          id={0}
+          title={'Error Occured'}
+          subTitle={errorMessage}
+          firstButton={errorCardButton?.name}
+          firstButtonType={'PRIMARY'}
+          onFirstButtonClick={errorCardButton?.onClick}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/widgets/src/error-banner/index.tsx
+++ b/packages/widgets/src/error-banner/index.tsx
@@ -1,0 +1,3 @@
+import { ErrorBanner, BannerType } from './error.banner';
+
+export { ErrorBanner, BannerType };

--- a/packages/widgets/src/typography/index.tsx
+++ b/packages/widgets/src/typography/index.tsx
@@ -1,3 +1,3 @@
-import { Colors, Typography } from './typography';
+import { Colors, Typography, Variants } from './typography';
 
-export { Colors, Typography };
+export { Colors, Typography, Variants };


### PR DESCRIPTION
## Changes

- User who is not privileged to download data will not to able to use plugin
- If user is privileged to download data then only token will be fetched
- When token fetch fails user will not be able to access plugin further
- Added error banners for both cases
- Added vercel analytics to track page visits and vercel insights.

## Pending/Not covered

- Currently report api returns 500 for any error, hence cannot add custom error message for api failure due to different reasons.

## Screenshots
![image](https://github.com/thoughtspot/plugin-party/assets/114509664/a6a26b5f-8fb5-4df2-b396-9431c8b17f6f)

![image](https://github.com/thoughtspot/plugin-party/assets/114509664/fd2e33ff-19da-4a9a-b810-0c8a01afb7f3)

![image](https://github.com/thoughtspot/plugin-party/assets/114509664/06e91618-528f-4663-a255-e5e128b355d7)
