### PR TITLE
SCAL-178153 : Disable modularHome in prerender Navigate issue

### DIFF
--- a/packages/slides/src/ui/components/liveboard/liveboard.tsx
+++ b/packages/slides/src/ui/components/liveboard/liveboard.tsx
@@ -114,6 +114,9 @@ const PrerenderedLiveboardShell = () => {
     }
     lbRef.current = new LiveboardEmbed(ref.current, {
       visibleActions: [Action.InsertInToSlide],
+      additionalFlags: {
+        modularHomeExperience: false,
+      },
       frameParams: {
         height: '100%',
       },


### PR DESCRIPTION
NavigateToLiveboard from prerender is not working in case of modularHome, when modular home is enabled when we try to open `/embed/viz`  it tries redirects to `/pinboard` in full app embed which is expected but it opens that in new tab, which I suppose is fixed by fe-infra, embed redirect will not open in new tab.